### PR TITLE
fix(ui): update online lobby info sections background color

### DIFF
--- a/.cursor/session-info.json
+++ b/.cursor/session-info.json
@@ -1,1 +1,1 @@
-{ "session_id": "20250624-1158", "branch_name": "session/20250624-1158-fix-ui-bugs", "start_time": "2025-06-24T10:58:02Z", "description": "Fix UI bugs", "changes_made": 7, "commits_made": 5 }
+{ "session_id": "20250624-1338", "branch_name": "session/20250624-1338-read-rules-and-follow", "start_time": "2025-06-24T12:38:26Z", "description": "Read rules and follow them", "changes_made": 0, "commits_made": 0 }

--- a/src/components/online/OnlineLobby/OnlineLobby.css
+++ b/src/components/online/OnlineLobby/OnlineLobby.css
@@ -306,10 +306,11 @@
 
 .game-rules,
 .room-settings {
-  background: white;
+  background: var(--color-background-light);
   padding: 1.5rem;
   border-radius: 12px;
   border: 2px solid var(--color-border);
+  border-left: 4px solid var(--color-primary);
 }
 
 .game-rules h4,


### PR DESCRIPTION
Prompt: bug fix in the online multiplayer game lobby

- Changed white backgrounds in lobby-info sections to match theme
- Added left border accent matching setup-help style
- Improved visual consistency across the application